### PR TITLE
version 0.1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PTYQoL"
 uuid = "551ad714-b11a-4605-8871-12721def4e72"
 authors = ["Tianyi Pu <912396513@qq.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [weakdeps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ClassicalOrthogonalPolynomials = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 
 [targets]
-test = ["Test", "LinearAlgebra", "Documenter", "DomainSets", "ContinuumArrays", "ClassicalOrthogonalPolynomials", "InfiniteArrays", "ArrayLayouts"]
+test = ["Test", "Aqua", "LinearAlgebra", "Documenter", "DomainSets", "ContinuumArrays", "ClassicalOrthogonalPolynomials", "InfiniteArrays", "ArrayLayouts"]

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -72,4 +72,7 @@ front(A::CartesianIndex) = CartesianIndex(front(Tuple(A)))
 tail(A::CartesianIndex) = CartesianIndex(tail(Tuple(A)))
 getindex(A::CartesianIndex, i) = CartesianIndex(Tuple(A)[i])
 
+import Base: copy
+copy(t::Tuple) = t
+
 end

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -5,8 +5,9 @@ include("Utils.jl")
 import Base: //
 //(x, y) = x / y
 
-import Base: eps, ceil, floor
+import Base: eps, ceil, floor, precision
 eps(::Type{Complex{T}}) where T = eps(T)
+precision(::Type{Complex{T}}) where T = precision(T)
 ceil(z::Complex; args...) = ceil(real(z), args...) + ceil(imag(z), args...)im
 floor(z::Complex; args...) = floor(real(z), args...) + floor(imag(z), args...)im
 

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -58,7 +58,7 @@ inv(f::ComposedFunction) = inv(f.inner) ∘ inv(f.outer)
 import Base: ==
 ==(f::Function, ::typeof(identity)) = isone(f)
 ==(::typeof(identity), f::Function) = isone(f)
-==(::typeof(identity), ::typeof(identity)) = true
+==(::typeof(identity), ::typeof(identity)) = true # ambiguity
 
 import Base: getproperty, Fix2
 getproperty(x) = Fix2(getproperty, x)

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -58,6 +58,7 @@ inv(f::ComposedFunction) = inv(f.inner) ∘ inv(f.outer)
 import Base: ==
 ==(f::Function, ::typeof(identity)) = isone(f)
 ==(::typeof(identity), f::Function) = isone(f)
+==(::typeof(identity), ::typeof(identity)) = true
 
 import Base: getproperty, Fix2
 getproperty(x) = Fix2(getproperty, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using PTYQoL
-using Test, Documenter
+using Test
 
 @testset "Pull Requests" begin
     @testset "https://github.com/JuliaLang/julia/issues/35033" begin
@@ -108,7 +108,13 @@ end
     end
 end
 
+using Documenter
 DocMeta.setdocmeta!(PTYQoL, :DocTestSetup, :(using PTYQoL); recursive=true)
 @testset "Docs" begin
 	doctest(PTYQoL)
+end
+
+using Aqua
+@testset "Project quality" begin
+    Aqua.test_all(PTYQoL, ambiguities=true, piracies=false, deps_compat=false)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,8 +37,9 @@ end
         @test LinearAlgebra.BLAS.dotu(u, v) == LinearAlgebra.BLAS.dotu(u, 1, v, 1) == LinearAlgebra.BLAS.dotu(10, u, 1, v, 1)
     end
 
-    @testset "eps ceil floor" begin
+    @testset "Complex interface" begin
         @test eps(ComplexF64) == eps(Float64)
+        @test precision(ComplexF64) == precision(Float64)
         @test ceil(0.5+0.5im) == 1+1im == floor(1.5+1.5im)
     end
 
@@ -60,6 +61,10 @@ end
         @test Fix2(+, 3) ^ 5 == Fix2(+, 15)
         @test Fix2(*, 4) ^ 3 == Fix2(*, 64)
         @test Fix2(^, 2) ∘ Fix2(^, 3) == Fix2(^, 6)
+    end
+
+    @testset "Tuple copy" begin
+        @test copy((1,2)) ≡ (1,2)
     end
 end
 


### PR DESCRIPTION
- `precision(::Type{Complex{T}}) where T = precision(T)`
- Add `struct_copy` to generate codes for `Base.copy`.
- `copy(t::Tuple) = t`