### PR TITLE
Version 0.2.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuasiArrays = "c4ea9172-b204-11e9-377d-29865faadc5c"
 
@@ -32,6 +33,7 @@ PTYQoLDomainSetsExt = "DomainSets"
 PTYQoLInfiniteArraysExt = "InfiniteArrays"
 PTYQoLInfinitiesExt = "Infinities"
 PTYQoLIntervalSetsExt = "IntervalSets"
+PTYQoLIrrationalConstantsExt = "IrrationalConstants"
 PTYQoLLinearAlgebraExt = "LinearAlgebra"
 PTYQoLQuasiArraysExt = "QuasiArrays"
 
@@ -46,4 +48,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "LinearAlgebra", "Documenter", "DomainSets", "ContinuumArrays", "ClassicalOrthogonalPolynomials", "ArrayLayouts", "AlgebraicNumbers", "Infinities", "BlockBandedMatrices", "BandedMatrices", "CircularArrays", "IntervalSets", "QuasiArrays", "InfiniteArrays", "BlockArrays", "BeepBeep"]
+test = ["Test", "Aqua", "LinearAlgebra", "Documenter", "DomainSets", "ContinuumArrays", "ClassicalOrthogonalPolynomials", "ArrayLayouts", "AlgebraicNumbers", "Infinities", "BlockBandedMatrices", "BandedMatrices", "CircularArrays", "IntervalSets", "IrrationalConstants", "QuasiArrays", "InfiniteArrays", "BlockArrays", "BeepBeep"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,46 +4,46 @@ authors = ["Tianyi Pu <912396513@qq.com> and contributors"]
 version = "0.2.5"
 
 [weakdeps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+AlgebraicNumbers = "e86d093a-a386-599e-b7c7-df0420c8bcba"
+ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 CircularArrays = "7a955b69-7140-5f4e-a0ed-f168c5e2e749"
+ClassicalOrthogonalPolynomials = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
 ContinuumArrays = "7ae1f121-cc2c-504b-ac30-9b923412ae5c"
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuasiArrays = "c4ea9172-b204-11e9-377d-29865faadc5c"
-ClassicalOrthogonalPolynomials = "b30e2e7b-c4ee-47da-9d5f-2c5c27239acd"
-BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-AlgebraicNumbers = "e86d093a-a386-599e-b7c7-df0420c8bcba"
 
 [extensions]
-PTYQoLLinearAlgebraExt = "LinearAlgebra"
+PTYQoLAlgebraicNumbersExt = "AlgebraicNumbers"
+PTYQoLArrayLayoutsExt = "ArrayLayouts"
+PTYQoLBandedMatricesExt = "BandedMatrices"
 PTYQoLBlockArraysExt = "BlockArrays"
 PTYQoLBlockBandedMatricesExt = "BlockBandedMatrices"
 PTYQoLCircularArraysExt = "CircularArrays"
+PTYQoLClassicalOrthogonalPolynomialsExt = "ClassicalOrthogonalPolynomials"
 PTYQoLContinuumArraysExt = "ContinuumArrays"
 PTYQoLDomainSetsExt = "DomainSets"
 PTYQoLInfiniteArraysExt = "InfiniteArrays"
 PTYQoLInfinitiesExt = "Infinities"
 PTYQoLIntervalSetsExt = "IntervalSets"
+PTYQoLLinearAlgebraExt = "LinearAlgebra"
 PTYQoLQuasiArraysExt = "QuasiArrays"
-PTYQoLClassicalOrthogonalPolynomialsExt = "ClassicalOrthogonalPolynomials"
-PTYQoLBandedMatricesExt = "BandedMatrices"
-PTYQoLArrayLayoutsExt = "ArrayLayouts"
-PTYQoLAlgebraicNumbersExt = "AlgebraicNumbers"
 
 [compat]
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BeepBeep = "97dd0070-d6c0-43ac-b134-ca84cdbd343e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BeepBeep = "97dd0070-d6c0-43ac-b134-ca84cdbd343e"
 
 [targets]
 test = ["Test", "Aqua", "LinearAlgebra", "Documenter", "DomainSets", "ContinuumArrays", "ClassicalOrthogonalPolynomials", "ArrayLayouts", "AlgebraicNumbers", "Infinities", "BlockBandedMatrices", "BandedMatrices", "CircularArrays", "IntervalSets", "QuasiArrays", "InfiniteArrays", "BlockArrays", "BeepBeep"]

--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ Full of type piracies. However they are not supposed to break anything. They onl
 
 **Remark** Technically this package does break things. Due to the extension, some method errors are eliminated, so if you rely on those errors, don't use this package.
 
+This package should be only guaranteed to support the latest stable version of Julia.
+
 Rule of new version:
 - `(It's been at least 24 hrs since the last version) && ((an external PR is merged) || (an issue is resolved) || (the number of line changes reach 100)`

--- a/ext/PTYQoLAlgebraicNumbersExt.jl
+++ b/ext/PTYQoLAlgebraicNumbersExt.jl
@@ -22,10 +22,4 @@ float(x::AlgebraicNumber) = x.apprx
 (::Type{T})(x::AlgebraicNumber) where T<:AbstractFloat = T(x.apprx)
 AlgebraicNumber(x::AlgebraicNumber) = x
 
-# ambiguities
-import Base: promote_rule
-import AlgebraicNumbers: AlgebraicNumber
-
-promote_rule(::Type{Bool},::Type{AlgebraicNumber{S,F}}) where {S,F} = AlgebraicNumber
-
 end # module

--- a/ext/PTYQoLAlgebraicNumbersExt.jl
+++ b/ext/PTYQoLAlgebraicNumbersExt.jl
@@ -22,4 +22,10 @@ float(x::AlgebraicNumber) = x.apprx
 (::Type{T})(x::AlgebraicNumber) where T<:AbstractFloat = T(x.apprx)
 AlgebraicNumber(x::AlgebraicNumber) = x
 
+# ambiguities
+import Base: promote_rule
+import AlgebraicNumbers: AlgebraicNumber
+
+promote_rule(::Type{Bool},::Type{AlgebraicNumber{S,F}}) where {S,F} = AlgebraicNumber
+
 end # module

--- a/ext/PTYQoLAlgebraicNumbersExt.jl
+++ b/ext/PTYQoLAlgebraicNumbersExt.jl
@@ -1,25 +1,13 @@
 module PTYQoLAlgebraicNumbersExt
 
 import AlgebraicNumbers: sin_alg, cos_alg, AlgebraicNumber
-import Base: sinpi, cospi, tanpi, sincospi, sind, cosd, sincosd, promote_rule, float
+import Base: promote_rule, float
 
-export tan_alg, sincos_alg
-
-tan_alg(x) = sin_alg(x) // cos_alg(x)
-sincos_alg(x) = (sin_alg(x), cos_alg(x))
-
-for (fd, fpi, falg) in ((:sind, :sinpi, :sin_alg), (:cosd, :cospi, :cos_alg), (:tand, :tanpi, :tan_alg), (:sincosd, :sincospi, :sincos_alg))
-    @eval begin
-        $fpi(x::Rational) = $falg(x)
-        $fpi(x::AlgebraicNumber) = $falg(x)
-        $fd(x::Integer) = $falg(x//180)
-        $fd(x::Rational) = $falg(x//180)
-    end
-end
-
+# https://github.com/anj1/AlgebraicNumbers.jl/pull/35
 promote_rule(::Type{<:AlgebraicNumber}, ::Type{T}) where T <: AbstractFloat = T
 float(x::AlgebraicNumber) = x.apprx
 (::Type{T})(x::AlgebraicNumber) where T<:AbstractFloat = T(x.apprx)
+
 AlgebraicNumber(x::AlgebraicNumber) = x
 
 end # module

--- a/ext/PTYQoLBandedMatricesExt.jl
+++ b/ext/PTYQoLBandedMatricesExt.jl
@@ -1,7 +1,7 @@
 module PTYQoLBandedMatricesExt
 
-import BandedMatrices: inbands_getindex, inbands_setindex!, AbstractBandedMatrix, bandwidths, MemoryLayout, BandedLayout
-import Base: getindex, setindex!, @propagate_inbounds
+import BandedMatrices: inbands_getindex, inbands_setindex!, AbstractBandedMatrix, bandwidths, MemoryLayout, BandedLayout, BandedMatrix
+import Base: getindex, setindex!, @propagate_inbounds, convert
 
 # too tedious to test
 
@@ -28,5 +28,7 @@ end
         error("out of band.")
     end
 end
+
+convert(::Type{AbstractArray{T}}, M::BandedMatrix{T}) where T = M
 
 end

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -10,7 +10,7 @@ import Base: OneTo, similar, reshape
 rowsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
 colsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
-reshape(block_array::PseudoBlockArray, axes::Tuple{}) where N = _pseudo_reshape(block_array, axes)
+reshape(block_array::PseudoBlockArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
 reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(PseudoBlockArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{}) = reshape(PseudoBlockArray(block_array), dims)
 

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -11,5 +11,7 @@ rowsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
 colsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
 reshape(block_array::PseudoBlockArray, axes::Tuple{}) where N = _pseudo_reshape(block_array, axes)
+reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(PseudoBlockArray(block_array), dims)
+reshape(block_array::BlockArray, dims::Tuple{}) = reshape(PseudoBlockArray(block_array), dims)
 
 end # module

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -1,5 +1,13 @@
 module PTYQoLBlockArraysExt
 
+import BlockArrays: findblockindex, BlockIndex
+import Base.IteratorsMD: flatten
+
+function findblockindex(A::AbstractArray{T,N}, I::Tuple{Vararg{Integer,N}}) where {T,N}
+    blockinds = findblockindex.(axes(A), I)
+    BlockIndex(flatten(map(x->x.I, blockinds)), flatten(map(x->x.α, blockinds)))
+end
+
 # ambiguities
 import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, PseudoBlockArray, _pseudo_reshape
 import Base: OneTo, similar, reshape

--- a/ext/PTYQoLDomainSetsExt.jl
+++ b/ext/PTYQoLDomainSetsExt.jl
@@ -1,12 +1,10 @@
 module PTYQoLDomainSetsExt
 
 # ambiguities
-import DomainSets: AnyDomain, setdiffdomain, domain, AffineMap, isaffine, matrix, vector, isequaldomain, uniondomain, _intersect, DomainStyle
-import Base: setdiff, ==, convert, union, intersect
+import DomainSets: AnyDomain, setdiffdomain, domain, AffineMap, isaffine, matrix, vector, isequaldomain, uniondomain, DomainStyle
+import Base: setdiff, ==, convert, union
 
 setdiff(d1::AbstractSet, d2::AnyDomain) = setdiffdomain(d1, domain(d2))
-
-intersect(d1::AbstractSet, d2::AnyDomain, domains...) = _intersect(d1, domain(d2), DomainStyle(d1), domains...)
 
 union(d1::BitSet, d2::AnyDomain, domains...) = uniondomain(d1, domain(d2), domains...)
 

--- a/ext/PTYQoLDomainSetsExt.jl
+++ b/ext/PTYQoLDomainSetsExt.jl
@@ -12,7 +12,4 @@ union(d1::BitSet, d2::AnyDomain, domains...) = uniondomain(d1, domain(d2), domai
 ==(::AnyDomain, ::Missing) = missing
 ==(::Missing, ::AnyDomain) = missing
 
-convert(::Type{AffineMap}, m::AffineMap) = m
-convert(::Type{AffineMap{T}}, m::AffineMap{T}) where T = m
-
 end # module

--- a/ext/PTYQoLInfinitiesExt.jl
+++ b/ext/PTYQoLInfinitiesExt.jl
@@ -6,10 +6,13 @@ import Infinities: InfiniteCardinal, ∞, Infinity, ComplexInfinity, RealInfinit
 
 RealInfinity(x::Complex) = RealInfinity(Bool(x))
 RealInfinity(x::TwicePrecision) = RealInfinity(Bool(x))
+RealInfinity(x::AbstractChar) = RealInfinity(Bool(x))
 ComplexInfinity(x::Complex) = ComplexInfinity(Real(x))
-ComplexInfinity{T}(x::AbstractChar) where T<:Real = ComplexInfinity(Real(x))
+ComplexInfinity{T}(x::TwicePrecision) where T<:Real = ComplexInfinity(T(x))
+ComplexInfinity{T}(x::AbstractChar) where T<:Real = ComplexInfinity(T(x))
 
 Bool(x::RealInfinity) = _convert(Bool, x)
+Bool(x::Infinity) = _convert(Bool, x)
 
 +(::InfiniteCardinal, x::Rational) = ∞ + x
 +(x::Rational, ::InfiniteCardinal) = x + ∞

--- a/ext/PTYQoLIrrationalConstantsExt.jl
+++ b/ext/PTYQoLIrrationalConstantsExt.jl
@@ -1,0 +1,36 @@
+module PTYQoLIrrationalConstantsExt
+
+using IrrationalConstants
+import Base: +, -, *, /, inv, sqrt, exp, log
+
+# x+x=2x, 2x-x=x, x/2x=1/2, 2x/x=2
+for (x, halfx) in ((halfπ,quartπ), (π,halfπ), (twoπ,π), (fourπ,twoπ), (inv2π,inv4π), (invπ,inv2π), (twoinvπ,invπ), (fourinvπ,twoinvπ), (sqrt2,invsqrt2), (sqrt2π,sqrthalfπ), (sqrt4π,sqrtπ))
+    @eval +(::$(typeof(halfx)), ::$(typeof(halfx))) = $x
+    @eval -(::$(typeof(x)), ::$(typeof(halfx))) = $halfx
+    @eval /(::$(typeof(halfx)), ::$(typeof(x))) = 1/2
+    @eval /(::$(typeof(x)), ::$(typeof(halfx))) = 2
+end
+
+# x*inv(x)=1
+for (x,invx) in ((quartπ,fourinvπ), (halfπ,twoinvπ), (π,invπ), (twoπ,inv2π), (fourπ,inv4π), (sqrt2,invsqrt2), (sqrtπ,invsqrtπ), (sqrt2π,invsqrt2π))
+    @eval inv(::$(typeof(x))) = $invx
+    @eval inv(::$(typeof(invx))) = $x
+    @eval *(::$(typeof(x)), ::$(typeof(invx))) = 1
+    @eval *(::$(typeof(invx)), ::$(typeof(x))) = 1
+end
+
+# sqrt(x)*sqrt(x)=x, x/sqrt(x)=sqrt(x)
+for (x,sqrtx) in ((π,sqrtπ), (twoπ,sqrt2π), (fourπ,sqrt4π), (halfπ,sqrthalfπ), (invπ,invsqrtπ), (inv2π,invsqrt2π))
+    @eval sqrt(::$(typeof(x))) = $sqrtx
+    @eval *(::$(typeof(sqrtx)), ::$(typeof(sqrtx))) = $x
+    @eval /(::$(typeof(x)), ::$(typeof(sqrtx))) = $sqrtx
+    @eval /(::$(typeof(sqrtx)), ::$(typeof(x))) = inv($sqrtx)
+end
+
+# exp(log(x))=x
+for (x,logx) in ((π,logπ), (twoπ,log2π), (fourπ,log4π))
+    @eval log(::$(typeof(x))) = $logx
+    @eval exp(::$(typeof(logx))) = $x
+end
+
+end # module

--- a/ext/PTYQoLQuasiArraysExt.jl
+++ b/ext/PTYQoLQuasiArraysExt.jl
@@ -23,12 +23,7 @@ convert(::Type{Ref{T}}, x::QuasiCartesianIndex{1}) where {T} = RefValue{T}(x)::R
 
 @inline to_indices(A::AbstractQuasiArray, I::Tuple{}) = to_indices(A, axes(A), I)
 
-# this change happens at https://github.com/JuliaLang/julia/pull/45869
-@static if VERSION <= v"1.10.1"
-    to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Union{Tuple{BitArray{N}}, Tuple{Array{Bool, N}}}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
-else
-    to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Tuple{AbstractArray{Bool, N}, Vararg}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
-end
+to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Union{Tuple{BitArray{N}}, Tuple{Array{Bool, N}}}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
 
 _to_subscript_indices(A::AbstractQuasiMatrix, J::Tuple, Jrem::Tuple) = J
 _to_subscript_indices(A::AbstractQuasiMatrix, J::Tuple, Jrem::Tuple{}) = __to_subscript_indices(A, axes(A), J, Jrem)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,10 +118,6 @@ end
     end
     @testset "AlgebraicNumbers" begin
         using AlgebraicNumbers
-        @test sincospi(1//3) == sincosd(60) == (sqrt(AlgebraicNumber(3))/2, 0.5)
-        @test tanpi(1//3) == sqrt(AlgebraicNumber(3))
-        @test sincospi(1//3) isa NTuple{2,AlgebraicNumber}
-        @test tanpi(1//3) isa AlgebraicNumber
     end
     @testset "Infinities" begin
         using Infinities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,10 @@ end
 end
 
 @testset "Extensions" begin
+    @testset "BlockArrays" begin
+        using BlockArrays
+        @test findblockindex(mortar(reshape([randn(2,2), randn(1,2), randn(2,3), randn(1,3)],2,2)),(2,3)) == BlockIndex((1,2),(2,1))
+    end
     @testset "IntervalSets" begin
         using DomainSets
         @test union(ChebyshevInterval()) ≡ ChebyshevInterval()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,8 +119,32 @@ end
     @testset "AlgebraicNumbers" begin
         using AlgebraicNumbers
     end
-    @testset "Infinities" begin
-        using Infinities
+    @testset "IrrationalConstants" begin
+        using IrrationalConstants
+        @testset "half" begin
+            for (x, halfx) in ((halfπ,quartπ), (π,halfπ), (twoπ,π), (fourπ,twoπ), (inv2π,inv4π), (invπ,inv2π), (twoinvπ,invπ), (fourinvπ,twoinvπ), (sqrt2,invsqrt2), (sqrt2π,sqrthalfπ), (sqrt4π,sqrtπ))
+                @test halfx + halfx === x
+                @test x - halfx === halfx
+                @test halfx / x === 0.5
+                @test x / halfx === 2
+            end
+        end
+        @testset "inv" begin
+            for (x,invx) in ((quartπ,fourinvπ), (halfπ,twoinvπ), (π,invπ), (twoπ,inv2π), (fourπ,inv4π), (sqrt2,invsqrt2), (sqrtπ,invsqrtπ), (sqrt2π,invsqrt2π))
+                @test inv(x) === invx
+                @test inv(invx) === x
+                @test x*invx === 1
+                @test invx*x === 1
+            end
+        end
+        @testset "sqrt" begin
+            for (x,sqrtx) in ((π,sqrtπ), (twoπ,sqrt2π), (fourπ,sqrt4π), (halfπ,sqrthalfπ), (invπ,invsqrtπ), (inv2π,invsqrt2π))
+                @test sqrt(x) === sqrtx
+                @test sqrtx*sqrtx === x
+                @test x/sqrtx === sqrtx
+                @test sqrtx/x === inv(sqrtx)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
- resolve ambiguities
- remove an ambiguity resolution due to https://github.com/JuliaApproximation/DomainSets.jl/commit/fded373cbe02be975ab04a8d0a5338e4a8d47740
- remove an ambiguity resolution due to https://github.com/anj1/AlgebraicNumbers.jl/compare/v0.1.10...v0.1.11
- remove two ambiguity resolutions due to https://github.com/JuliaApproximation/DomainSets.jl/commit/38f27e0b513ac579a995b64b012976c2a6ce4e8e
- https://github.com/JuliaArrays/BlockArrays.jl/pull/345
- remove breaking methods in PTYQoLAlgebraicNumbersExt.jl
- add PTYQoLIrrationalConstantsExt.jl