### PR TITLE
remove PTYQoLCircularArraysExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PTYQoL"
 uuid = "551ad714-b11a-4605-8871-12721def4e72"
 authors = ["Tianyi Pu <912396513@qq.com> and contributors"]
-version = "0.2.7"
+version = "0.2.8"
 
 [weakdeps]
 AlgebraicNumbers = "e86d093a-a386-599e-b7c7-df0420c8bcba"

--- a/ext/PTYQoLBandedMatricesExt.jl
+++ b/ext/PTYQoLBandedMatricesExt.jl
@@ -29,6 +29,4 @@ end
     end
 end
 
-convert(::Type{AbstractArray{T}}, M::BandedMatrix{T}) where T = M
-
 end

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -9,14 +9,14 @@ function findblockindex(A::AbstractArray{T,N}, I::Tuple{Vararg{Integer,N}}) wher
 end
 
 # ambiguities
-import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, PseudoBlockArray, _pseudo_reshape
+import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, BlockedArray, _pseudo_reshape
 import Base: OneTo, similar, reshape
 
 @inline similar(::BlockArray, ::Type{T}, axes::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where T = BlockArray{T}(undef, map(to_axes,axes))
 @inline similar(::BlockArray, ::Type{T}, axes::Tuple{Integer, Vararg{Integer}}) where T = BlockArray{T}(undef, map(to_axes,axes))
 
-rowsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
-colsupport(A::PseudoBlockArray, i::CartesianIndex{2}) = colsupport(A, last(i))
+rowsupport(A::BlockedArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
+colsupport(A::BlockedArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
 reshape(block_array::PseudoBlockArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
 reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(PseudoBlockArray(block_array), dims)

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -9,7 +9,7 @@ function findblockindex(A::AbstractArray{T,N}, I::Tuple{Vararg{Integer,N}}) wher
 end
 
 # ambiguities
-import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, BlockedArray, _pseudo_reshape
+import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, BlockedArray, _blocked_reshape
 import Base: OneTo, similar, reshape
 
 @inline similar(::BlockArray, ::Type{T}, axes::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where T = BlockArray{T}(undef, map(to_axes,axes))

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -18,8 +18,8 @@ import Base: OneTo, similar, reshape
 rowsupport(A::BlockedArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
 colsupport(A::BlockedArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
-reshape(block_array::PseudoBlockArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
-reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(PseudoBlockArray(block_array), dims)
-reshape(block_array::BlockArray, dims::Tuple{}) = reshape(PseudoBlockArray(block_array), dims)
+reshape(block_array::BlockedArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
+reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(BlockedArray(block_array), dims)
+reshape(block_array::BlockArray, dims::Tuple{}) = reshape(BlockedArray(block_array), dims)
 
 end # module

--- a/ext/PTYQoLCircularArraysExt.jl
+++ b/ext/PTYQoLCircularArraysExt.jl
@@ -1,19 +1,3 @@
 module PTYQoLCircularArraysExt
 
-import CircularArrays: CircularArray
-"""
-    CircularMatrix{T,A} <: AbstractVector{T}
-    
-Two-dimensional array backed by an `AbstractArray{T, 2}` of type `A` with fixed size and circular indexing.
-Alias for [`CircularArray{T,2,A}`](@ref).
-"""
-const CircularMatrix{T} = CircularArray{T, 2}
-
-# ambiguities
-import Base: similar
-import CircularArrays: CircularArray, _similar
-
-# https://github.com/Vexatos/CircularArrays.jl/pull/31
-@inline similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where T = _similar(arr, T, dims)
-
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -246,8 +246,8 @@ julia> fracpochhammer(1, 2, 0.5, 1, 3) # (1 * 1.5 * 2) / (2 * 3 * 4)
 0.125
 ```
 """
-fracpochhammer(a,b,n) = prod(x/y for (x,y) in zip(range(a,length=n),range(b,length=n)))
-fracpochhammer(a,b,stepa,stepb,n) = prod(x/y for (x,y) in zip(range(a,step=stepa,length=n),range(b,step=stepb,length=n)))
+fracpochhammer(a,b,n) = prod((x/y for (x,y) in zip(range(a,length=n),range(b,length=n))), init=1)
+fracpochhammer(a,b,stepa,stepb,n) = prod((x/y for (x,y) in zip(range(a,step=stepa,length=n),range(b,step=stepb,length=n))), init=1)
 
 const TupleN{T,N} = Tuple{Vararg{T,N}}
 const Tuple1N{T,N} = Tuple{T, Vararg{T,N}}

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -192,6 +192,10 @@ macro struct_map(TYP, ops...)
     end)
 end
 
+export indent
+indent(s::AbstractString, t::AbstractString) = t*replace(s, "\n" => "\n"*t)
+indent(s::AbstractString, k::Integer) = indent(s, repeat(' ', k))
+
 import Base: Fix1, show, string
 export ln
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,7 @@ using Aqua
         for m in extension
             display(m[1])
             display(m[2])
-            Aqua.ambiguity_hint(m...)
+            Aqua.ambiguity_hint(stdout, m...)
             print("\n\n\n")
         end
         println("There are $(length(extension)) ambiguities that can be solved by extension.")


### PR DESCRIPTION
- resolve #12 
- remove an ambiguity resolution due to https://github.com/Vexatos/CircularArrays.jl/pull/31
- adapt to https://github.com/JuliaTesting/Aqua.jl/pull/281
- remove an ambiguity resolution due to https://github.com/JuliaLinearAlgebra/BandedMatrices.jl/pull/443
- change `BlockArrays.PseudoBlockArray` to `BlockArrays.BlockedArray` due to https://github.com/JuliaArrays/BlockArrays.jl/pull/401
- change `BlockArrays._pseudo_reshape` to `BlockArrays_blocked_reshape` due to https://github.com/JuliaArrays/BlockArrays.jl/pull/255/commits/11e1f2686d87b8fa436dafbfbb4b741e4ac6c7e9#diff-27de6e9a9ec3e50bfd54e0027eb7aab2f223cb23229f463ba767c249308e912e