### PR TITLE
Version 0.2.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+/statprof

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,5 @@
 # PTYQoL.jl
 
-Documentation for PTYQoL.jl
-
 ```@autodocs
 Modules = [PTYQoL]
 ```

--- a/docs/src/piracies.md
+++ b/docs/src/piracies.md
@@ -1,0 +1,16 @@
+## Type piracies
+
+### Extended support on `Complex`
+```jldoctest
+julia> eps(1.0+im)
+2.220446049250313e-16
+
+julia> precision(1.0+im)
+53
+
+julia> ceil(0.5+0.5im)
+1.0 + 1.0im
+
+julia> floor(0.5+0.5im)
+0.0 + 0.0im
+```

--- a/docs/src/piracies.md
+++ b/docs/src/piracies.md
@@ -1,6 +1,6 @@
-## Type piracies
+# Type piracies
 
-### Extended support on `Complex`
+## `Complex` supports `eps`, `precision`, `ceil` and `floor`
 ```jldoctest
 julia> eps(1.0+im)
 2.220446049250313e-16
@@ -14,3 +14,5 @@ julia> ceil(0.5+0.5im)
 julia> floor(0.5+0.5im)
 0.0 + 0.0im
 ```
+
+##

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -18,7 +18,6 @@ import Base: OneTo, similar, reshape
 rowsupport(A::BlockedArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
 colsupport(A::BlockedArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
-reshape(block_array::BlockedArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
 reshape(block_array::BlockVector, dims::Tuple{Colon}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{Integer, Vararg{Integer}}) = reshape(BlockedArray(block_array), dims)

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -21,6 +21,5 @@ colsupport(A::BlockedArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 reshape(block_array::BlockVector, dims::Tuple{Colon}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{Integer, Vararg{Integer}}) = reshape(BlockedArray(block_array), dims)
-reshape(block_array::BlockArray, dims::Tuple{}) = reshape(BlockedArray(block_array), dims)
 
 end # module

--- a/ext/PTYQoLBlockArraysExt.jl
+++ b/ext/PTYQoLBlockArraysExt.jl
@@ -9,7 +9,7 @@ function findblockindex(A::AbstractArray{T,N}, I::Tuple{Vararg{Integer,N}}) wher
 end
 
 # ambiguities
-import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, BlockedArray, _blocked_reshape
+import BlockArrays: BlockArray, to_axes, colsupport, rowsupport, BlockedArray, _blocked_reshape, BlockVector
 import Base: OneTo, similar, reshape
 
 @inline similar(::BlockArray, ::Type{T}, axes::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where T = BlockArray{T}(undef, map(to_axes,axes))
@@ -19,7 +19,9 @@ rowsupport(A::BlockedArray, i::CartesianIndex{2}) = rowsupport(A, first(i))
 colsupport(A::BlockedArray, i::CartesianIndex{2}) = colsupport(A, last(i))
 
 reshape(block_array::BlockedArray, axes::Tuple{}) = _pseudo_reshape(block_array, axes)
+reshape(block_array::BlockVector, dims::Tuple{Colon}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{Vararg{Int}}) = reshape(BlockedArray(block_array), dims)
+reshape(block_array::BlockArray, dims::Tuple{Integer, Vararg{Integer}}) = reshape(BlockedArray(block_array), dims)
 reshape(block_array::BlockArray, dims::Tuple{}) = reshape(BlockedArray(block_array), dims)
 
 end # module

--- a/ext/PTYQoLDomainSetsExt.jl
+++ b/ext/PTYQoLDomainSetsExt.jl
@@ -2,11 +2,12 @@ module PTYQoLDomainSetsExt
 
 # ambiguities
 import DomainSets: AnyDomain, setdiffdomain, domain, AffineMap, isaffine, matrix, vector, isequaldomain, uniondomain, DomainStyle
-import Base: setdiff, ==, convert, union
+import Base: setdiff, ==, convert, union, intersect, @deprecate
 
 setdiff(d1::AbstractSet, d2::AnyDomain) = setdiffdomain(d1, domain(d2))
 
 union(d1::BitSet, d2::AnyDomain, domains...) = uniondomain(d1, domain(d2), domains...)
+@deprecate intersect(d1::AbstractSet, d2::AnyDomain) intersect(DomainRef(d1), d2)
 
 ==(d1::AnyDomain, d2::WeakRef) = isequaldomain(domain(d1), d2)
 ==(::AnyDomain, ::Missing) = missing

--- a/ext/PTYQoLInfiniteArraysExt.jl
+++ b/ext/PTYQoLInfiniteArraysExt.jl
@@ -2,7 +2,7 @@ module PTYQoLInfiniteArraysExt
 
 # ambiguities
 import InfiniteArrays: RealInfinity, PosInfinity, ℵ₀, InfiniteCardinal
-import Base: Colon, getindex, OverflowSafe, (:), getindex, OneTo, unitrange_last
+import Base: Colon, getindex, OverflowSafe, (:), getindex, OneTo, unitrange_last, _sub2ind_recurse
 
 (:)(start::RealInfinity, step::AbstractFloat, stop::RealInfinity) = (:)(promote(start, step)..., stop)
 (:)(::PosInfinity, ::AbstractFloat, ::PosInfinity) = throw(ArgumentError("Cannot create range starting at infinity"))
@@ -22,5 +22,10 @@ function getindex(x::OneTo{T}, y::InfiniteCardinal{0}) where T
 end
 
 unitrange_last(::Integer, ::InfiniteCardinal{0}) = ∞
+
+function _sub2ind_recurse(::Tuple{}, L::InfiniteCardinal{0}, ind, i::Integer, I::Vararg{Integer})
+    @inline
+    _sub2ind_recurse((), L, ind+(i-1)*L, I...)
+end
 
 end # module

--- a/ext/PTYQoLInfiniteArraysExt.jl
+++ b/ext/PTYQoLInfiniteArraysExt.jl
@@ -12,7 +12,7 @@ function getindex(x::UnitRange{<:OverflowSafe}, y::InfiniteCardinal{0})
     isinf(length(x)) || throw(BoundsError(x,y))
     ℵ₀
 end
-function getindex(x::UnitRange, y::InfiniteCardinal{0})
+function getindex(x::UnitRange{T}, y::InfiniteCardinal{0}) where T
     isinf(length(x)) || throw(BoundsError(x,y))
     ℵ₀
 end

--- a/ext/PTYQoLQuasiArraysExt.jl
+++ b/ext/PTYQoLQuasiArraysExt.jl
@@ -22,8 +22,15 @@ convert(::Type{T}, index::QuasiCartesianIndex{1}) where {T>:Union{Missing, Nothi
 convert(::Type{Ref{T}}, x::QuasiCartesianIndex{1}) where {T} = RefValue{T}(x)::RefValue{T}
 
 @inline to_indices(A::AbstractQuasiArray, I::Tuple{}) = to_indices(A, axes(A), I)
+@inline to_indices(A::AbstractQuasiArray, I::Tuple{AbstractArray{Bool}}) = to_indices(A, axes(A), I)
 
 to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Union{Tuple{BitArray{N}}, Tuple{Array{Bool, N}}}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
+to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Tuple{AbstractArray{CartesianIndex{N}}, Vararg}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
+to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Tuple{AbstractArray{Bool, N}, Vararg}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
+to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Tuple{CartesianIndex{N}, Vararg}) where N = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
+to_indices(A::AbstractQuasiArray, inds, I::Tuple{AbstractArray{CartesianIndex{N}}, Vararg}) where N = (@_inline_meta; (to_quasi_index(A, eltype(inds[1]), I[1]), to_indices(A, _cutdim(inds, I[1]), tail(I))...))
+to_indices(A::AbstractQuasiArray, ::Tuple{}, I::Tuple{Colon, Vararg}) = (@_inline_meta; (to_index(A, I[1]), to_indices(A, (), tail(I))...))
+to_indices(A::AbstractQuasiArray, inds, I::Tuple{AbstractArray{Bool, N}, Vararg}) where N = (@_inline_meta; (to_quasi_index(A, eltype(inds[1]), I[1]), to_indices(A, _cutdim(inds, I[1]), tail(I))...))
 
 _to_subscript_indices(A::AbstractQuasiMatrix, J::Tuple, Jrem::Tuple) = J
 _to_subscript_indices(A::AbstractQuasiMatrix, J::Tuple, Jrem::Tuple{}) = __to_subscript_indices(A, axes(A), J, Jrem)

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -23,12 +23,16 @@ startswith(a, b) = startswith(string(a), string(b))
 endswith(a, b) = endswith(string(a), string(b))
 
 # https://github.com/JuliaLang/julia/pull/48894
-import Base: AbstractRange, AbstractArray
-AbstractRange{T}(r::AbstractRange) where {T} = T(first(r)):T(step(r)):T(last(r))
-AbstractArray{T,1}(r::AbstractRange) where {T} = AbstractRange{T}(r)
-AbstractArray{T}(r::AbstractRange) where {T} = AbstractRange{T}(r)
-AbstractRange{T}(r::AbstractUnitRange) where {T<:Integer} = AbstractUnitRange{T}(r)
-AbstractRange{T}(r::StepRangeLen) where {T} = StepRangeLen{T}(r)
+import Base: AbstractRange, AbstractArray, OrdinalRange
+AbstractRange{T}(r::AbstractRange) where T = range(T(first(r)), T(last(r)), length(r))
+AbstractRange{T}(r::OrdinalRange) where T<:Integer = OrdinalRange{T}(r) # float should fall back to StepRangeLen
+AbstractRange{T}(r::OrdinalRange) where T<:Rational = OrdinalRange{T}(r)
+AbstractRange{T}(r::StepRangeLen) where T = StepRangeLen{T}(r)
+AbstractRange{T}(r::LinRange) where T = LinRange{T}(r)
+AbstractArray{T,1}(r::AbstractRange) where T = AbstractRange{T}(r)
+AbstractArray{T}(r::AbstractRange) where T = AbstractRange{T}(r)
+OrdinalRange{T}(r::OrdinalRange{R,S}) where {T, R, S} = OrdinalRange{T, promote_type(T,S)}(r) # type of step matters
+OrdinalRange{T}(r::AbstractUnitRange) where T = AbstractUnitRange{T}(r) # not in this case
 
 import Base: Fix2, Fix1, isone, ^, ∘, inv
 # problematic in terms of type consistency, but these are not supported by Base at all.

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -24,10 +24,11 @@ endswith(a, b) = endswith(string(a), string(b))
 
 # https://github.com/JuliaLang/julia/pull/48894
 import Base: AbstractRange, AbstractArray
-AbstractRange{T}(r::AbstractRange) where {T<:Real} = T(first(r)):T(step(r)):T(last(r))
-AbstractArray{T,1}(r::AbstractRange) where {T<:Real} = AbstractRange{T}(r)
-AbstractArray{T}(r::AbstractRange) where {T<:Real} = AbstractRange{T}(r)
+AbstractRange{T}(r::AbstractRange) where {T} = T(first(r)):T(step(r)):T(last(r))
+AbstractArray{T,1}(r::AbstractRange) where {T} = AbstractRange{T}(r)
+AbstractArray{T}(r::AbstractRange) where {T} = AbstractRange{T}(r)
 AbstractRange{T}(r::AbstractUnitRange) where {T<:Integer} = AbstractUnitRange{T}(r)
+AbstractRange{T}(r::StepRangeLen) where {T} = StepRangeLen{T}(r)
 
 import Base: Fix2, Fix1, isone, ^, ∘, inv
 # problematic in terms of type consistency, but these are not supported by Base at all.

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -102,7 +102,6 @@ import Base: mapreduce
 mapreduce(f, op) = f()
 
 import Base: searchsorted, searchsortedfirst, searchsortedlast, Ordering, Forward, ord, keytype, midpoint, lt
-keytype(::Tuple) = Int
 
 function searchsortedfirst(v, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
     hi = hi + T(1)

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -4,6 +4,8 @@ include("Utils.jl")
 
 import Base: //
 //(x, y) = x / y
+# https://github.com/JuliaLang/julia/issues/52870
+//(A::AbstractMatrix{<:Integer}, B::AbstractMatrix{<:Integer}) = (A//one(eltype(A))) / (B//one(eltype(B)))
 
 import Base: eps, ceil, floor, precision
 eps(::Type{Complex{T}}) where {T} = eps(T)

--- a/src/PTYQoL.jl
+++ b/src/PTYQoL.jl
@@ -7,7 +7,9 @@ import Base: //
 
 import Base: eps, ceil, floor, precision
 eps(::Type{Complex{T}}) where {T} = eps(T)
+eps(::Complex{T}) where T = eps(Complex{T})
 precision(::Type{Complex{T}}) where {T} = precision(T)
+precision(::Complex{T}) where T = precision(Complex{T})
 ceil(z::Complex; args...) = ceil(real(z), args...) + ceil(imag(z), args...)im
 floor(z::Complex; args...) = floor(real(z), args...) + floor(imag(z), args...)im
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
 
     @testset "https://github.com/JuliaLang/julia/pull/48894" begin
         @test AbstractRange{Float64}(1:10) ≡ AbstractVector{Float64}(1:10) ≡ AbstractArray{Float64}(1:10) ≡ 1.0:10
+        @test AbstractArray{Float64}(0*(1:10)) ≡ range(0.0,0.0,10)
     end
 
     @testset "https://github.com/JuliaLang/julia/pull/52312" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,17 @@ using Test
         @test front(ind) == ind[1:end-1] == CartesianIndex(1, 2)
         @test tail(ind) == ind[2:end] == CartesianIndex(2, 3)
     end
+
+    @testset "https://github.com/JuliaLang/julia/issues/52870" begin
+        using LinearAlgebra
+        A = rand(1:9, 3, 3)
+        B = rand(1:9, 3, 3)
+        while det(B) == 0
+            B = rand(1:9, 3, 3)
+        end
+        C = A // B
+        @test C * B == A
+    end
 end
 
 @testset "Misc" begin


### PR DESCRIPTION
- remove `keytype(::Tuple)` due to https://github.com/JuliaLang/julia/pull/49179
- resolve ambiguities
- remove two ambiguity resolvers due to https://github.com/JuliaArrays/BlockArrays.jl/pull/410
- move to Julia 1.11
- add `eps(::Complex)` and `precision(::Complex)`
- update on https://github.com/JuliaLang/julia/pull/48894
- support matrix `//` https://github.com/JuliaLang/julia/issues/52870